### PR TITLE
add the missing requirements.txt file from torch-rnn repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Cython==0.23.4
+numpy==1.10.4
+argparse==1.2.1
+h5py==2.5.0
+six==1.10.0
+wsgiref==0.1.2


### PR DESCRIPTION
This requirements file is a necessary piece in the dependencies for training your own model, as per the README. I've copied it over from the original torch-rnn repo