### PR TITLE
require newer version of h5py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cython==0.23.4
 numpy==1.10.4
 argparse==1.2.1
-h5py==2.5.0
+h5py==2.7.0
 six==1.10.0
 wsgiref==0.1.2


### PR DESCRIPTION
fixes an error (after clean installation) where the older version of h5py would fail to import. It would say, ValueError: Not a property list class (Not a property list class).  See here for similar issue. https://github.com/h5py/h5py/issues/616